### PR TITLE
Support installation via Homebrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,49 +9,50 @@
 -->
 
 ## master
+* Added support for installation via Homebrew. - [Cihat Gündüz](https://github.com/Dschee) (Issue [#17](https://github.com/rockbruno/SwiftInfo/issues/17), PR [#20](https://github.com/rockbruno/SwiftInfo/pull/20))
 
 ## 2.2.0
-* Added LargestAssetProvider - Bruno Rocha
-* Changed how SwiftInfo generates summary results to allow custom providers to make use of SwiftInfo-Reader - Bruno Rocha
-* Small visual improvements to summaries - Bruno Rocha
+* Added LargestAssetProvider - [Bruno Rocha](https://github.com/rockbruno)
+* Changed how SwiftInfo generates summary results to allow custom providers to make use of SwiftInfo-Reader - [Bruno Rocha](https://github.com/rockbruno)
+* Small visual improvements to summaries - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 2.1.0
-* Added ArchiveTimeProvider - Bruno Rocha
-* SwiftInfo will now continue executing even if a provider fails (the reasons are printed in the final summary) - Bruno Rocha
-* Improvements to the durability of many providers and fixing minor bugs related to them - Bruno Rocha
-* Fixed many providers silently failing if Xcode's new build system was active - Bruno Rocha
-* Fixed many providers reporting empty results when they should have failed - Bruno Rocha
+* Added ArchiveTimeProvider - [Bruno Rocha](https://github.com/rockbruno)
+* SwiftInfo will now continue executing even if a provider fails (the reasons are printed in the final summary) - [Bruno Rocha](https://github.com/rockbruno)
+* Improvements to the durability of many providers and fixing minor bugs related to them - [Bruno Rocha](https://github.com/rockbruno)
+* Fixed many providers silently failing if Xcode's new build system was active - [Bruno Rocha](https://github.com/rockbruno)
+* Fixed many providers reporting empty results when they should have failed - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 2.0.2
-* Fixed some providers reporting wrong colors for the result - Bruno Rocha
+* Fixed some providers reporting wrong colors for the result - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 2.0.1
-* Fixed LongestTest's provider not working with non-legacy workspaces - Bruno Rocha
+* Fixed LongestTest's provider not working with non-legacy workspaces - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 2.0.0
-* Added support for arguments - Bruno Rocha
-* Updated to Swift 5 - Bruno Rocha
-* Improved CodeCoverageProvider and LinesOfCodeProvider - Bruno Rocha
+* Added support for arguments - [Bruno Rocha](https://github.com/rockbruno)
+* Updated to Swift 5 - [Bruno Rocha](https://github.com/rockbruno)
+* Improved CodeCoverageProvider and LinesOfCodeProvider - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 1.2.0
-* Added LinesOfCodeProvider - Bruno Rocha
-* Slightly improved generic summary messages - Bruno Rocha
+* Added LinesOfCodeProvider - [Bruno Rocha](https://github.com/rockbruno)
+* Slightly improved generic summary messages - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 1.1.0
-* Linked sourcekitd to allow extraction of code related metrics - Bruno Rocha
-* Added OBJCFileCountProvider - Bruno Rocha
-* Added LongestTestDurationProvider - Bruno Rocha
-* Added TotalTestDurationProvider - Bruno Rocha
-* Added LargestAssetCatalogProvider - Bruno Rocha
-* Added TotalAssetCatalogsSizeProvider - Bruno Rocha
+* Linked sourcekitd to allow extraction of code related metrics - [Bruno Rocha](https://github.com/rockbruno)
+* Added OBJCFileCountProvider - [Bruno Rocha](https://github.com/rockbruno)
+* Added LongestTestDurationProvider - [Bruno Rocha](https://github.com/rockbruno)
+* Added TotalTestDurationProvider - [Bruno Rocha](https://github.com/rockbruno)
+* Added LargestAssetCatalogProvider - [Bruno Rocha](https://github.com/rockbruno)
+* Added TotalAssetCatalogsSizeProvider - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 1.0.0
-* Added Unit Tests - Bruno Rocha
-* InfoProvider's `extract() -> Self` is now `extract(fromApi api: SwiftInfo) -> Self` - Bruno Rocha
-* Revamped logs - Bruno Rocha
+* Added Unit Tests - [Bruno Rocha](https://github.com/rockbruno)
+* InfoProvider's `extract() -> Self` is now `extract(fromApi api: SwiftInfo) -> Self` - [Bruno Rocha](https://github.com/rockbruno)
+* Revamped logs - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 0.1.1
-* Fixed dylib search paths by using `--driver-mode=swift` when running `swiftc` - Bruno Rocha
+* Fixed dylib search paths by using `--driver-mode=swift` when running `swiftc` - [Bruno Rocha](https://github.com/rockbruno)
 
 ## 0.1.0
 (Initial Release)

--- a/Formula/swiftinfo.rb
+++ b/Formula/swiftinfo.rb
@@ -1,0 +1,12 @@
+class Swiftinfo < Formula
+  desc "📊 Extract and analyze the evolution of an iOS app's code."
+  homepage "https://github.com/rockbruno/SwiftInfo"
+  url "https://github.com/rockbruno/SwiftInfo.git", :tag => "2.2.0", :revision => "4dc083130a0b519307436c7083e3d417d1aea870"
+  head "https://github.com/rockbruno/SwiftInfo.git"
+
+  depends_on :xcode => ["10.2", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+end

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,46 @@
-prepare:
-	swift build -c release --disable-sandbox
-	./prepare_for_release.sh
+SHELL = /bin/bash
 
-package:
-	tar -zcvf "swiftinfo-2.2.0.tar.gz" ./bin
+prefix ?= /usr/local
+bindir ?= $(prefix)/bin
+libdir ?= $(prefix)/lib
+srcdir = Sources
+
+REPODIR = $(shell pwd)
+BUILDDIR = $(REPODIR)/.build
+SOURCES = $(wildcard $(srcdir)/**/*.swift)
+
+.DEFAULT_GOAL = all
+
+.PHONY: all
+all: swiftinfo
+
+swiftinfo: $(SOURCES)
+	@swift build \
+		-c release \
+		--disable-sandbox \
+		--build-path "$(BUILDDIR)"
+
+.PHONY: install
+install: swiftinfo
+	@install -d "$(bindir)" "$(libdir)"
+	@install "$(BUILDDIR)/release/swiftinfo" "$(bindir)"
+	@cp -a "$(REPODIR)/Sources/Csourcekitd/." "$(bindir)/Csourcekitd"
+
+.PHONY: portable_zip
+portable_zip: swiftinfo
+	rm -f "$(BUILDDIR)/release/portable_swiftinfo.zip"
+	zip -j "$(BUILDDIR)/release/portable_swiftinfo.zip" "$(BUILDDIR)/release/swiftinfo" "$(REPODIR)/LICENSE"
+	echo "Portable ZIP created at: $(BUILDDIR)/release/portable_swiftinfo.zip"
+
+.PHONY: uninstall
+uninstall:
+	@rm -rf "$(bindir)/swiftinfo"
+	@rm -rf "$(bindir)/Csourcekitd"
+
+.PHONY: clean
+distclean:
+	@rm -f $(BUILDDIR)/release
+
+.PHONY: clean
+clean: distclean
+	@rm -rf $(BUILDDIR)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ SwiftInfo is a simple CLI tool that extracts, tracks and analyzes metrics that a
 
 ## Usage
 
-SwiftInfo requires the raw logs of a succesful test/archive build combo to work, so it's better used as the last step of a CI pipeline. 
+SwiftInfo requires the raw logs of a succesful test/archive build combo to work, so it's better used as the last step of a CI pipeline.
 
 ### Retrieving raw logs with Fastlane
 
@@ -35,12 +35,12 @@ If you use Fastlane, you can expose the raw logs after building by adding `build
 ```ruby
 desc "Submits a new beta build and runs SwiftInfo"
 lane :beta do
-  # Run tests, copying the raw logs to the project folder 
+  # Run tests, copying the raw logs to the project folder
   scan(
     scheme: "MyScheme",
     buildlog_path: "./build/tests_log"
   )
-    
+
   # Archive the app, copying the raw logs to the project folder and the .ipa to the /build folder
   gym(
     workspace: "MyApp.xcworkspace",
@@ -48,7 +48,7 @@ lane :beta do
     output_directory: "build",
     buildlog_path: "./build/build_log"
   )
- 
+
   # Send to TestFlight
   pilot(
       skip_waiting_for_build_processing: true
@@ -177,6 +177,21 @@ Documentation of useful types and methods from SwiftInfoCore that you can use wh
 **If you end up creating a custom provider, consider submitting it here as a pull request to have it added as a default one!**
 
 ## Installation
+
+### [Homebrew](https://brew.sh/) (Recommended)
+
+To install SwiftInfo the first time, simply run these commands:
+
+```bash
+brew tap rockbruno/SwiftInfo https://github.com/rockbruno/SwiftInfo.git
+brew install swiftinfo
+```
+
+To **update** to the newest version of SwiftINfo when you have an old version already installed run:
+
+```bash
+brew upgrade swiftinfo
+```
 
 ### CocoaPods
 

--- a/Sources/SwiftInfoCore/FileUtils/FileUtils.swift
+++ b/Sources/SwiftInfoCore/FileUtils/FileUtils.swift
@@ -18,12 +18,16 @@ public struct FileUtils {
     }
 
     public var toolFolder: String {
-        guard let executionPath = ProcessInfo.processInfo.arguments.first,
-              let url = URL(string: executionPath)?.deletingLastPathComponent().absoluteString else
-        {
+        guard let executablePath = ProcessInfo.processInfo.arguments.first else {
             fail("Couldn't determine the folder that's running SwiftInfo.")
         }
-        return url
+
+        let executableUrl = URL(fileURLWithPath: executablePath)
+        if let isAliasFile = try! executableUrl.resourceValues(forKeys: [URLResourceKey.isAliasFileKey]).isAliasFile, isAliasFile {
+            return try! URL(resolvingAliasFileAt: executableUrl).deletingLastPathComponent().path
+        } else {
+            return executableUrl.deletingLastPathComponent().path
+        }
     }
 
     public func infofileFolder() throws -> String {

--- a/Sources/SwiftInfoCore/Runner.swift
+++ b/Sources/SwiftInfoCore/Runner.swift
@@ -13,9 +13,9 @@ public enum Runner {
             fileUtils.toolFolder,
             "-lSwiftInfoCore",
             "-Xcc",
-            "-fmodule-map-file=\(fileUtils.toolFolder)Csourcekitd/include/module.modulemap",
+            "-fmodule-map-file=\(fileUtils.toolFolder)/Csourcekitd/include/module.modulemap",
             "-I",
-            "\(fileUtils.toolFolder)Csourcekitd/include",
+            "\(fileUtils.toolFolder)/Csourcekitd/include",
             (try! fileUtils.infofileFolder()) + "Infofile.swift",
             "-toolchain",
             "\(toolchainPath)"] + Array(processInfoArgs.dropFirst()) // Route SwiftInfo args to the sub process


### PR DESCRIPTION
Please note that for this to actually work, you will need to do the following steps:

1. Make a new tagged release (must be committed before next step)
2. Update the `Formula/swiftinfo.rb` with the correct tagged commit and its commit hash

Then, this should actually work. I have already tested this by making tagged releases (e.g. `50.50.50`) in my fork and pointing the Formula to my fork, it worked with the changes in e7050a6. (Basically the commit fixes issues with symlinks, cause Homebrew only adds a symlink to the final executable path.)

Note that you can now install the tool locally by running `make install` and uninstall it via `make uninstall`. Also I added a `make portable_zip` command which you may need to insert a `copy` command into, then you should even be able to remove the `prepare_for_release.sh` script. But I leave that choice to you. @rockbruno 

This fixes #17.