### PR TITLE
Update xcodeproj package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {
           "branch": null,
-          "revision": "54bb8ea6fb693dd3f92a89e5fcc19e199fdeedd0",
-          "version": "4.3.3"
+          "revision": "e4d517844dd03dac557e35d77a8e9ab438de91a6",
+          "version": "4.4.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
         }
       },
       {
@@ -29,21 +29,12 @@
         }
       },
       {
-        "package": "SwiftShell",
-        "repositoryURL": "https://github.com/kareman/SwiftShell",
-        "state": {
-          "branch": null,
-          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
-          "version": "4.1.2"
-        }
-      },
-      {
-        "package": "xcodeproj",
+        "package": "XcodeProj",
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "3fe1bd763072c81050b867d34db56d11cb9085bb",
-          "version": "6.6.0"
+          "revision": "f32704e01d2752bdc17cde3963bee4256c1f4df4",
+          "version": "7.8.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .executable(name: "swiftinfo", targets: ["SwiftInfo"])
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/xcodeproj.git", .exact("6.6.0"))
+        .package(url: "https://github.com/tuist/xcodeproj.git", .exact("7.8.0"))
     ],
     targets: [
         // Csourcekitd: C modules wrapper for sourcekitd.
@@ -21,7 +21,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SwiftInfoCore",
-            dependencies: ["Csourcekitd", "xcodeproj"]),
+            dependencies: ["Csourcekitd", "XcodeProj"]),
         .target(
             name: "SwiftInfo",
             dependencies: ["SwiftInfoCore"]),

--- a/Sources/SwiftInfoCore/ProjectInfo/PlistExtractor.swift
+++ b/Sources/SwiftInfoCore/ProjectInfo/PlistExtractor.swift
@@ -1,6 +1,6 @@
 import Foundation
 import PathKit
-import xcodeproj
+import XcodeProj
 
 public protocol PlistExtractor {
     func extractPlistPath(xcodeproj: String,


### PR DESCRIPTION
Updates the XcodeProj package to fix errors with resolving Xcodeproj in Xcode 11 projects which contain Swift packages.

https://github.com/tuist/xcodeproj/issues/442

We ran into some issues running SwiftInfo out of the box since our  Xcode project has a few Swift Packages included.  The older version of the Xcodeproj swift library didn't support this.  The package name changed also for whatever reason.  