### PR TITLE
Swaps original implementation with Argument parse

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
+        }
+      },
+      {
         "package": "XcodeProj",
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
         .executable(name: "swiftinfo", targets: ["SwiftInfo"])
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/xcodeproj.git", .exact("7.8.0"))
+        .package(url: "https://github.com/tuist/xcodeproj.git", .exact("7.8.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [
         // Csourcekitd: C modules wrapper for sourcekitd.
@@ -24,7 +25,7 @@ let package = Package(
             dependencies: ["Csourcekitd", "XcodeProj"]),
         .target(
             name: "SwiftInfo",
-            dependencies: ["SwiftInfoCore"]),
+            dependencies: ["SwiftInfoCore", "ArgumentParser"]),
         .testTarget(
             name: "SwiftInfoTests",
             dependencies: ["SwiftInfo"]),

--- a/Sources/SwiftInfo/main.swift
+++ b/Sources/SwiftInfo/main.swift
@@ -10,6 +10,11 @@ struct Swiftinfo: ParsableCommand {
         subcommands: []
     )
 
+    /// since we are using .unconditionalRemaining --help doesnt work anymore
+    /// Thus we added a manual flag here
+    @Flag(name: .shortAndLong, help: "Show help information.")
+    var help = false
+
     @Flag(name: .shortAndLong, help: "silent all logs")
     var silent = false
 
@@ -22,7 +27,15 @@ struct Swiftinfo: ParsableCommand {
     @Flag(name: .customLong("print-sourcekit", withSingleDash: true), help: "print source kit")
     var printSourcekit = false
 
+    @Argument(parsing: .unconditionalRemaining)
+    var arguments: [String] = []
+
     mutating func run() throws {
+        if help {
+            print(Swiftinfo.helpMessage())
+            Swiftinfo.exit()
+        }
+
         setupLogConfig()
         guard let executablePath = CommandLine.arguments.first else {
             fail("Couldn't determine the folder that's running SwiftInfo.")

--- a/Sources/SwiftInfo/main.swift
+++ b/Sources/SwiftInfo/main.swift
@@ -4,10 +4,11 @@ import SwiftInfoCore
 
 let task = Process()
 
-struct SwiftInfo: ParsableCommand {
-
-    @Flag(name: .long, help: "return current version of `SwiftInfo`")
-    var version = false
+struct Swiftinfo: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        abstract: "Swiftinfo 2.3.12",
+        subcommands: []
+    )
 
     @Flag(name: .shortAndLong, help: "silent all logs")
     var silent = false
@@ -15,26 +16,19 @@ struct SwiftInfo: ParsableCommand {
     @Flag(name: .shortAndLong, help: "logs all details to console")
     var verbose = false
 
-    @Flag(name: .long, help: "is in pull request mode")
+    @Flag(name: .customLong("pullRequest", withSingleDash: true), help: "is in pull request mode")
     var pullRequest = false
 
-    @Flag(name: .long, help: "print source kit")
-    var sourceKit = false
-
-    @Argument(help: "One or more user related Swiftc Args")
-    var arguments: [String] = []
+    @Flag(name: .customLong("print-sourcekit", withSingleDash: true), help: "print source kit")
+    var printSourcekit = false
 
     mutating func run() throws {
         setupLogConfig()
-        if version {
-            log("SwiftInfo 2.3.12")
-            SwiftInfo.exit()
-        }
         guard let executablePath = CommandLine.arguments.first else {
             fail("Couldn't determine the folder that's running SwiftInfo.")
         }
         let fileUtils = FileUtils(path: executablePath)
-        let toolchainPath = SwiftInfo.getToolchainPath()
+        let toolchainPath = Swiftinfo.getToolchainPath()
 
         log("Dylib Folder: \(fileUtils.toolFolder)", verbose: true)
         log("Infofile Path: \(try! fileUtils.infofileFolder())", verbose: true)
@@ -42,7 +36,7 @@ struct SwiftInfo: ParsableCommand {
 
         let args = Runner.getCoreSwiftCArguments(fileUtils: fileUtils,
                                                  toolchainPath: toolchainPath,
-                                                 processInfoArgs: arguments)
+                                                 processInfoArgs: Array(CommandLine.arguments.dropFirst()))
             .joined(separator: " ")
 
         log("Swiftc Args: \(args)", verbose: true)
@@ -53,7 +47,7 @@ struct SwiftInfo: ParsableCommand {
         task.standardError = FileHandle.standardError
 
         task.terminationHandler = { t -> Void in
-            SwiftInfo.exit()
+            Swiftinfo.exit()
         }
 
         task.launch()
@@ -79,7 +73,7 @@ struct SwiftInfo: ParsableCommand {
         isInVerboseMode = verbose
         isInSilentMode = silent
         isInPullRequestMode = pullRequest
-        printSourceKitQueries = sourceKit
+        printSourceKitQueries = printSourcekit
     }
 }
 
@@ -95,5 +89,5 @@ source.setEventHandler {
 ////////
 
 source.resume()
-SwiftInfo.main(CommandLine.arguments)
+Swiftinfo.main()
 dispatchMain()

--- a/Sources/SwiftInfoCore/FileUtils/FileUtils.swift
+++ b/Sources/SwiftInfoCore/FileUtils/FileUtils.swift
@@ -22,19 +22,20 @@ public struct FileUtils {
     /// The utility that opens and saves files.
     public let fileOpener: FileOpener
 
+    /// The path of the executable file
+    public let path: String
+
     public init(fileManager: FileManager = .default,
-                fileOpener: FileOpener = .init()) {
+                fileOpener: FileOpener = .init(),
+                path: String = "") {
         self.fileManager = fileManager
         self.fileOpener = fileOpener
+        self.path = path
     }
 
     /// The working path that is containing the SwiftInfo binary.
     public var toolFolder: String {
-        guard let executablePath = ProcessInfo.processInfo.arguments.first else {
-            fail("Couldn't determine the folder that's running SwiftInfo.")
-        }
-
-        let executableUrl = URL(fileURLWithPath: executablePath)
+        let executableUrl = URL(fileURLWithPath: path)
         if let isAliasFile = try! executableUrl.resourceValues(forKeys: [URLResourceKey.isAliasFileKey]).isAliasFile, isAliasFile {
             return try! URL(resolvingAliasFileAt: executableUrl).deletingLastPathComponent().path
         } else {

--- a/Sources/SwiftInfoCore/Logger.swift
+++ b/Sources/SwiftInfoCore/Logger.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public var isInVerboseMode = ProcessInfo.processInfo.arguments.contains("-v")
-public var isInSilentMode = ProcessInfo.processInfo.arguments.contains("-s")
-public var isInPullRequestMode = ProcessInfo.processInfo.arguments.contains("-pullRequest")
-public var printSourceKitQueries = ProcessInfo.processInfo.arguments.contains("-print-sourcekit")
+public var isInVerboseMode = false
+public var isInSilentMode = false
+public var isInPullRequestMode = false
+public var printSourceKitQueries = false
 
 public func log(_ message: String, verbose: Bool = false, sourceKit: Bool = false, hasPrefix: Bool = true) {
     guard isInSilentMode == false else {

--- a/Sources/SwiftInfoCore/Runner.swift
+++ b/Sources/SwiftInfoCore/Runner.swift
@@ -20,6 +20,6 @@ public enum Runner {
             (try! fileUtils.infofileFolder()) + "Infofile.swift",
             "-toolchain",
             "\(toolchainPath)",
-        ] + Array(processInfoArgs.dropFirst()) // Route SwiftInfo args to the sub process
+        ] + processInfoArgs // Route SwiftInfo args to the sub process
     }
 }

--- a/Tests/SwiftInfoTests/FileUtilsTests.swift
+++ b/Tests/SwiftInfoTests/FileUtilsTests.swift
@@ -13,7 +13,7 @@ final class FileUtilsTests: XCTestCase {
         FileUtils.testLogFilePath = ""
         fileManager = MockFileManager()
         fileOpener = MockFileOpener(mockFM: fileManager)
-        fileUtils = FileUtils(fileManager: fileManager, fileOpener: fileOpener)
+        fileUtils = FileUtils(fileManager: fileManager, fileOpener: fileOpener, path: "")
     }
 
     func testInfofileFinder() {

--- a/Tests/SwiftInfoTests/ProviderTests/ProviderTests.swift
+++ b/Tests/SwiftInfoTests/ProviderTests/ProviderTests.swift
@@ -5,7 +5,7 @@ extension SwiftInfo {
     static func mock() -> SwiftInfo {
         let fileManager = MockFileManager()
         let fileOpener = MockFileOpener(mockFM: fileManager)
-        let fileUtils = FileUtils(fileManager: fileManager, fileOpener: fileOpener)
+        let fileUtils = FileUtils(fileManager: fileManager, fileOpener: fileOpener, path: "")
         fileManager.add(file: "./Infofile.swift", contents: "")
         let projectInfo = ProjectInfo(xcodeproj: "Mock.xcproject",
                                       target: "Mock",


### PR DESCRIPTION
Good afternoon,

This PR should address the following issue #49 where `ProcessInfo` was swapped in favor of `CommandLine` and `Argument parse`.  This allowed us to have the following for the commands:

1- 
```
USAGE: swift-info [--version] [--silent] [--verbose] [--pull-request] [--source-kit] [<arguments> ...]

ARGUMENTS:
  <arguments>             One or more user related Swiftc Args 

OPTIONS:
  --version               return current version of `SwiftInfo` 
  -s, --silent            silent all logs 
  -v, --verbose           logs all details to console 
  --pull-request          is in pull request mode 
  --source-kit            print source kit 
  -h, --help              Show help information.
```
2-  updating to `Argument parse`, allowed to migrate add path as a dependency for `FileUtils` instead of requesting within `public var toolFolder: String` 

3- Parsing the arguments for the logger can be done with the the parser instead of manually parsing them.