### PR TITLE
Revert to old processinfo format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     - name: Build
       run: make build
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     - name: Run tests
       run: swift test
     - name: Check the example project
       run: cd ./ExampleProject && make swiftinfo
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     - name: Package
       run: make package

--- a/Sources/SwiftInfo/main.swift
+++ b/Sources/SwiftInfo/main.swift
@@ -28,25 +28,24 @@ struct Swiftinfo: ParsableCommand {
     var arguments: [String] = []
 
     mutating func run() throws {
-        if help {
+        guard !help else {
             print(Swiftinfo.helpMessage())
-            Swiftinfo.exit()
+            return
         }
 
         setupLogConfig()
-        guard let executablePath = CommandLine.arguments.first else {
-            fail("Couldn't determine the folder that's running SwiftInfo.")
-        }
-        let fileUtils = FileUtils(path: executablePath)
-        let toolchainPath = Swiftinfo.getToolchainPath()
+
+        let fileUtils = FileUtils()
+        let toolchainPath = getToolchainPath()
 
         log("Dylib Folder: \(fileUtils.toolFolder)", verbose: true)
         log("Infofile Path: \(try! fileUtils.infofileFolder())", verbose: true)
         log("Toolchain Path: \(toolchainPath)", verbose: true)
 
+        let processInfoArgs = ProcessInfo.processInfo.arguments
         let args = Runner.getCoreSwiftCArguments(fileUtils: fileUtils,
                                                  toolchainPath: toolchainPath,
-                                                 processInfoArgs: Array(CommandLine.arguments.dropFirst()))
+                                                 processInfoArgs: processInfoArgs)
             .joined(separator: " ")
 
         log("Swiftc Args: \(args)", verbose: true)
@@ -63,7 +62,7 @@ struct Swiftinfo: ParsableCommand {
         task.launch()
     }
 
-    static func getToolchainPath() -> String {
+    private func getToolchainPath() -> String {
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", "xcode-select -p"]

--- a/Sources/SwiftInfoCore/FileUtils/FileUtils.swift
+++ b/Sources/SwiftInfoCore/FileUtils/FileUtils.swift
@@ -22,20 +22,19 @@ public struct FileUtils {
     /// The utility that opens and saves files.
     public let fileOpener: FileOpener
 
-    /// The path of the executable file
-    public let path: String
-
     public init(fileManager: FileManager = .default,
-                fileOpener: FileOpener = .init(),
-                path: String = "") {
+                fileOpener: FileOpener = .init()) {
         self.fileManager = fileManager
         self.fileOpener = fileOpener
-        self.path = path
     }
 
     /// The working path that is containing the SwiftInfo binary.
     public var toolFolder: String {
-        let executableUrl = URL(fileURLWithPath: path)
+        guard let executablePath = ProcessInfo.processInfo.arguments.first else {
+            fail("Couldn't determine the folder that's running SwiftInfo.")
+        }
+
+        let executableUrl = URL(fileURLWithPath: executablePath)
         if let isAliasFile = try! executableUrl.resourceValues(forKeys: [URLResourceKey.isAliasFileKey]).isAliasFile, isAliasFile {
             return try! URL(resolvingAliasFileAt: executableUrl).deletingLastPathComponent().path
         } else {

--- a/Sources/SwiftInfoCore/Runner.swift
+++ b/Sources/SwiftInfoCore/Runner.swift
@@ -20,6 +20,6 @@ public enum Runner {
             (try! fileUtils.infofileFolder()) + "Infofile.swift",
             "-toolchain",
             "\(toolchainPath)",
-        ] + processInfoArgs // Route SwiftInfo args to the sub process
+        ] + Array(processInfoArgs.dropFirst()) // Route SwiftInfo args to the sub process
     }
 }

--- a/Tests/SwiftInfoTests/FileUtilsTests.swift
+++ b/Tests/SwiftInfoTests/FileUtilsTests.swift
@@ -13,7 +13,7 @@ final class FileUtilsTests: XCTestCase {
         FileUtils.testLogFilePath = ""
         fileManager = MockFileManager()
         fileOpener = MockFileOpener(mockFM: fileManager)
-        fileUtils = FileUtils(fileManager: fileManager, fileOpener: fileOpener, path: "")
+        fileUtils = FileUtils(fileManager: fileManager, fileOpener: fileOpener)
     }
 
     func testInfofileFinder() {

--- a/Tests/SwiftInfoTests/ProviderTests/ProviderTests.swift
+++ b/Tests/SwiftInfoTests/ProviderTests/ProviderTests.swift
@@ -5,7 +5,7 @@ extension SwiftInfo {
     static func mock() -> SwiftInfo {
         let fileManager = MockFileManager()
         let fileOpener = MockFileOpener(mockFM: fileManager)
-        let fileUtils = FileUtils(fileManager: fileManager, fileOpener: fileOpener, path: "")
+        let fileUtils = FileUtils(fileManager: fileManager, fileOpener: fileOpener)
         fileManager.add(file: "./Infofile.swift", contents: "")
         let projectInfo = ProjectInfo(xcodeproj: "Mock.xcproject",
                                       target: "Mock",


### PR DESCRIPTION
Looks like calling CommandLine causes weird issues when calling the tool from scripts or other environments.