### PR TITLE
Add optional title prefix to sendToSlack

### DIFF
--- a/Sources/SwiftInfoCore/SlackFormatter.swift
+++ b/Sources/SwiftInfoCore/SlackFormatter.swift
@@ -3,13 +3,15 @@ import Foundation
 public struct SlackFormatter {
     public init() {}
 
-    public func format(output: Output, projectInfo: ProjectInfo) -> (json: [String: Any], message: String) {
-        let json = output.summaries.map { $0.slackDictionary }
-        let prefix = "SwiftInfo results for \(projectInfo.description):"
-        let errors = "\nErrors:\n\(output.errors.joined(separator: "\n"))"
-        let title = prefix + (output.errors.isEmpty ? "" : errors)
+    public func format(output: Output, titlePrefix: String?, projectInfo: ProjectInfo) -> (json: [String: Any], message: String) {
+        let errors = output.errors
+        let errorMessage = errors.isEmpty ? "" : "\nErrors:\n\(errors.joined(separator: "\n"))"
+
+        let title = (titlePrefix ?? "SwiftInfo results for ") + projectInfo.description + ":" + errorMessage
         let description = output.summaries.map { $0.text }.joined(separator: "\n")
         let message = title + "\n" + description
+
+        let json = output.summaries.map { $0.slackDictionary }
         return (["text": title, "attachments": json], message)
     }
 }

--- a/Sources/SwiftInfoCore/SwiftInfo.swift
+++ b/Sources/SwiftInfoCore/SwiftInfo.swift
@@ -62,10 +62,15 @@ public struct SwiftInfo {
     }
 
     /// Sends an output to slack.
-    public func sendToSlack(output: Output, webhookUrl: String) {
+    ///
+    /// - Parameters:
+    ///   - output: The output to send.
+    ///   - webhookUrl: The Slack webhook URL used to send the message.
+    ///   - titlePrefix: (Optional) The string to prepend to the message title such as team-mention, etc.
+    public func sendToSlack(output: Output, webhookUrl: String, titlePrefix: String? = nil) {
         log("Sending to Slack")
         log("Slack Webhook: \(webhookUrl)", verbose: true)
-        let formatted = slackFormatter.format(output: output, projectInfo: projectInfo)
+        let formatted = slackFormatter.format(output: output, titlePrefix: titlePrefix, projectInfo: projectInfo)
         client.syncPost(urlString: webhookUrl, json: formatted.json)
     }
 
@@ -74,7 +79,7 @@ public struct SwiftInfo {
     /// - Parameters:
     ///  - output: The output to print.
     public func print(output: Output) {
-        let formatted = slackFormatter.format(output: output, projectInfo: projectInfo)
+        let formatted = slackFormatter.format(output: output, titlePrefix: nil, projectInfo: projectInfo)
         // We print directly so that `log()`'s conditions don't interfere.
         // This is meant to be used with `danger-SwiftInfo` for printing to pull requests.
         Swift.print(formatted.message)

--- a/Tests/SwiftInfoTests/SlackFormatterTests.swift
+++ b/Tests/SwiftInfoTests/SlackFormatterTests.swift
@@ -6,7 +6,7 @@ final class SlackFormatterTests: XCTestCase {
         let swiftInfo = SwiftInfo.mock()
         let summaries = [Summary(text: "A", style: .positive, numericValue: 0, stringValue: "a")]
         let output = Output(rawDictionary: [:], summaries: summaries, errors: [])
-        let formatted = SlackFormatter().format(output: output, projectInfo: swiftInfo.projectInfo)
+        let formatted = SlackFormatter().format(output: output, titlePrefix: nil, projectInfo: swiftInfo.projectInfo)
         let dictionary = NSDictionary(dictionary: formatted.json)
         let expected: [String: Any] =
             [
@@ -16,11 +16,27 @@ final class SlackFormatterTests: XCTestCase {
         XCTAssertEqual(dictionary, NSDictionary(dictionary: expected))
     }
 
+    func testFormatterWithTitlePrefix() {
+        let swiftInfo = SwiftInfo.mock()
+        let prefix = "<!subteam^mention_id|ios-team>"
+        let summaries = [Summary(text: "A", style: .positive, numericValue: 0, stringValue: "a")]
+        let output = Output(rawDictionary: [:], summaries: summaries, errors: [])
+        let formatted = SlackFormatter().format(output: output, titlePrefix: prefix, projectInfo: swiftInfo.projectInfo)
+        let dictionary = NSDictionary(dictionary: formatted.json)
+        let text = prefix + "Mock 1.0 (1) - Mock-Debug:"
+        let expected: [String: Any] =
+            [
+                "attachments": [["color": "#36a64f","text": "A"]],
+                "text": text
+        ]
+        XCTAssertEqual(dictionary, NSDictionary(dictionary: expected))
+    }
+
     func testFormatterWithError() {
         let swiftInfo = SwiftInfo.mock()
         let summaries = [Summary(text: "A", style: .positive, numericValue: 0, stringValue: "a")]
         let output = Output(rawDictionary: [:], summaries: summaries, errors: ["abc", "cde"])
-        let formatted = SlackFormatter().format(output: output, projectInfo: swiftInfo.projectInfo)
+        let formatted = SlackFormatter().format(output: output, titlePrefix: nil, projectInfo: swiftInfo.projectInfo)
         let dictionary = NSDictionary(dictionary: formatted.json)
         let expected: [String: Any] =
             [
@@ -34,7 +50,7 @@ final class SlackFormatterTests: XCTestCase {
         let swiftInfo = SwiftInfo.mock()
         let summaries = [Summary(text: "A", style: .positive, numericValue: 0, stringValue: "a")]
         let output = Output(rawDictionary: [:], summaries: summaries, errors: [])
-        let formatted = SlackFormatter().format(output: output, projectInfo: swiftInfo.projectInfo)
+        let formatted = SlackFormatter().format(output: output, titlePrefix: nil, projectInfo: swiftInfo.projectInfo)
         XCTAssertEqual(formatted.message, "SwiftInfo results for Mock 1.0 (1) - Mock-Debug:\nA")
     }
 }


### PR DESCRIPTION
Addresses: https://github.com/rockbruno/SwiftInfo/issues/57

#### Usage

`api.sendToSlack(output: output, webhookUrl: url, titlePrefix: "<!subteam^mention_id|ios-team>")`



