### PR TITLE
Sort JSON keys if macOS version allows it

### DIFF
--- a/Sources/SwiftInfoCore/FileUtils/FileUtils.swift
+++ b/Sources/SwiftInfoCore/FileUtils/FileUtils.swift
@@ -132,7 +132,14 @@ public struct FileUtils {
         let path = try outputFileURL()
         log("Path to save: \(path.absoluteString)", verbose: true)
         let dictionary = ["data": output]
-        let json = try JSONSerialization.data(withJSONObject: dictionary, options: [.prettyPrinted])
+        let writingOptions: JSONSerialization.WritingOptions = {
+            if #available(OSX 10.13, *) {
+                return [.prettyPrinted, .sortedKeys]
+            } else {
+                return [.prettyPrinted]
+            }
+        }()
+        let json = try JSONSerialization.data(withJSONObject: dictionary, options: writingOptions)
         try? fileManager.createDirectory(atPath: try outputFileFolder(),
                                          withIntermediateDirectories: true,
                                          attributes: nil)


### PR DESCRIPTION
Hey 👋 

I've noticed this for awhile now but only now had the time to look into this. Here's the problem:

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/8419048/108138559-f86c7a80-709c-11eb-8a25-d19fba55dd70.png">

This is the diff of a single "swiftinfo update output json" commit. It's huge, it touches 5k lines, even though the json being appended has only 97 lines.

Solution: the json diff can be minimized (not entirely mitigated) by sorting the keys before printing. This is merely to reduce the number of lines changed, as this is increasing linearly overtime 😄 with this change, hopefully the only diff in the output json will be the lines added (thus `O(1)` instead of `O(n)`, where N is the number of entries existent in the json)

Tests are passing, but I couldn't really think of a decent way to test this other than comparing json the json with a string literal, but this way wouldn't be too reliable because when the keys are not sorted intentionally, they may still be "occasionally" sorted, which would make tests flaky. Open to suggestions here! 🙏 

Cheers!
