### PR TITLE
Module Stability Workarounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,26 @@ build:
 	@swift build \
 		-c release \
 		--disable-sandbox \
-		--build-path "$(BUILDDIR)"
+		--build-path "$(BUILDDIR)" \
+		-Xswiftc \
+		-emit-module-interface \
+		-Xswiftc \
+		-enable-library-evolution \
+		-Xswiftc \
+		-swift-version \
+		-Xswiftc 5
 	@rm -rf "$(PRODUCTDIR)"
 	@rm -rf "$(TEMPPRODUCTDIR)"
 	@mkdir -p "$(TEMPPRODUCTDIR)"
 	@mkdir -p "$(TEMPPRODUCTDIR)/include/swiftinfo"
+
+	@# Module Stability - Replace *.swiftmodules with *.swiftinterface
+	@mv *.swiftinterface $(RELEASEBUILDDIR)
+	@rm $(RELEASEBUILDDIR)/*.swiftmodule
+	@# Workaround for types that have the same name as the module
+	@# https://forums.swift.org/t/frameworkname-is-not-a-member-type-of-frameworkname-errors-inside-swiftinterface/28962
+	@sed -i '' 's/XcodeProj\.//g' $(RELEASEBUILDDIR)/XcodeProj.swiftinterface
+
 	@cp -a "$(RELEASEBUILDDIR)/." "$(TEMPPRODUCTDIR)/include/swiftinfo"
 	@cp -a "$(TEMPPRODUCTDIR)/." "$(PRODUCTDIR)"
 	@rm -rf "$(TEMPPRODUCTDIR)"

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ build:
 	@mkdir -p "$(TEMPPRODUCTDIR)"
 	@mkdir -p "$(TEMPPRODUCTDIR)/include/swiftinfo"
 
-	@# Module Stability - Replace *.swiftmodules with *.swiftinterface
+	@# Module Stability - Replace *.swiftmodule with *.swiftinterface
 	@mv *.swiftinterface $(RELEASEBUILDDIR)
 	@rm $(RELEASEBUILDDIR)/*.swiftmodule
-	@# Workaround for types that have the same name as the module
+	@# Workaround for types that have the same name as its module
 	@# https://forums.swift.org/t/frameworkname-is-not-a-member-type-of-frameworkname-errors-inside-swiftinterface/28962
 	@sed -i '' 's/XcodeProj\.//g' $(RELEASEBUILDDIR)/XcodeProj.swiftinterface
 


### PR DESCRIPTION
This pull request enables module stability for SwiftInfo releases, meaning you can use the same binary with any Swift >= 5 versions.

I did some hacky stuff to make it work, primarily updating `XcodeProj.swiftinterface` to work around some bugs.

Discussions in issue https://github.com/rockbruno/SwiftInfo/issues/68.

I'm going to leave this open here, feel free to close/update or propose other changes in case someone has a better solution.

I'm also closing https://github.com/rockbruno/SwiftInfo/issues/70 and using my fork because we are migrating to Xcode 12.5 in iFood.