### PR TITLE
-disallow-use-new-driver for Swift 5.5

### DIFF
--- a/Sources/SwiftInfoCore/Runner.swift
+++ b/Sources/SwiftInfoCore/Runner.swift
@@ -20,6 +20,9 @@ public enum Runner {
             (try! fileUtils.infofileFolder()) + "Infofile.swift",
             "-toolchain",
             "\(toolchainPath)",
+            // Swift 5.5 (from Xcode 13+) uses the new swift-driver which doesn't support -toolchain arg
+            // Disabling the driver for now as a workaround so it works with Swift 5.5 and older versions
+            "-disallow-use-new-driver",
         ] + Array(processInfoArgs.dropFirst()) // Route SwiftInfo args to the sub process
     }
 }


### PR DESCRIPTION
### Context

When I try to run SwiftInfo with Xcode 13 (Swift 5.5) I receive this error (from its internal `swiftc` invocation):

```
./swiftinfo 
error: unknown argument: '-toolchain'
```

Swift 5.5 uses the new [swift-driver](https://github.com/apple/swift-driver) by default (which apparently does not support the `-toolchain` arg):

```
swiftc -version
swift-driver version: 1.26.9 Apple Swift version 5.5 (swiftlang-1300.0.31.1 clang-1300.0.29.1)
Target: x86_64-apple-macosx11.0
```

We may also have more problems than that.  `Runner.swift` uses `--driver-mode=swift` which is also not working (does nothing) and breaks `Infofile` parsing.

### Solution (workaround)

Passing `-disallow-use-new-driver` to `swiftc` disables the new driver and everything works again. I tested with both Xcode 13 (Swift 5.5) and Xcode 12.5 (Swift 5.4) so it seems retro compatible.

We should eventually update to support the new driver, but I think the solution is ok for now.